### PR TITLE
Pass autoerror to parent

### DIFF
--- a/fastapimsal/frontend/authentication.py
+++ b/fastapimsal/frontend/authentication.py
@@ -48,7 +48,7 @@ class UserAuthenticatedToken(UserAuthenticated):
         self.f_save_cache = f_save_cache
         self.auto_error = auto_error
 
-        super().__init__(auto_error=False)
+        super().__init__(auto_error=auto_error)
 
     async def get_token_from_cache(
         self, user: UserId, scope: Optional[List[str]] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapimsal"
-version = "0.4.0"
+version = "0.4.1"
 description = "Library to authenticate users using MSAL"
 authors = ["Oscar Giles <ogiles@turing.ac.uk>"]
 


### PR DESCRIPTION
## Summary
<!-- What does your PR do? -->
Fix critical security bug. `UserAuthenticatedToken` was not passing on auto_error parameter to parent which meant it did not raise an HTTP error if not authenticated.

## Issues
<!--List issues this closes -->

## Reviewer
<!-- List anything you would like the reviewer to focus on. -->

## How to run
<!-- Explain how the reviewer should run the code. -->
